### PR TITLE
Subscribe

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/testing-library__jest-dom": "5.9.2",
     "@types/webpack": "4.41.22",
     "@types/webpack-env": "1.15.2",
+    "axios": "0.21.0",
     "chalk": "4.1.0",
     "cross-env": "7.0.2",
     "eslint-config-prettier": "6.11.0",

--- a/src/app/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/app/__tests__/__snapshots__/index.test.tsx.snap
@@ -31,6 +31,11 @@ exports[`<App /> should render and match the snapshot 1`] = `
     />
     <Route
       component={[Function]}
+      exact={true}
+      path="/confirmation"
+    />
+    <Route
+      component={[Function]}
     />
   </Switch>
   <Memo(GlobalStyleComponent) />

--- a/src/app/containers/ConfirmationPage/Loadable.tsx
+++ b/src/app/containers/ConfirmationPage/Loadable.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { lazyLoad } from 'utils/loadable';
+import { LoadingIndicator } from 'app/components/LoadingIndicator';
+import styled from 'styled-components/macro';
+
+const LoadingWrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ConfirmationPage = lazyLoad(
+  () => import('./index'),
+  module => module.ConfirmationPage,
+  {
+    fallback: (
+      <LoadingWrapper>
+        <LoadingIndicator />
+      </LoadingWrapper>
+    ),
+  },
+);

--- a/src/app/containers/ConfirmationPage/index.tsx
+++ b/src/app/containers/ConfirmationPage/index.tsx
@@ -9,13 +9,11 @@ import { useEffect, useState } from 'react';
 
 export function ConfirmationPage() {
   const { t } = useTranslation();
-
-  const  {state}  = useLocation();
-  // const { email, postalCode} = state;
-  // const [info, setInfo] = useState(state);
-  
+ 
+  const  {state} = useLocation();
   useEffect(()=>{
     console.log(state);
+    
   }, []);
   return (
     <>
@@ -29,7 +27,7 @@ export function ConfirmationPage() {
       <NavBar />
       <PageWrapper>
       <p>{JSON.stringify(state)}</p>
-      {/* <p>{state.postalCode}</p> */}
+      
       </PageWrapper>
     </>
   );

--- a/src/app/containers/ConfirmationPage/index.tsx
+++ b/src/app/containers/ConfirmationPage/index.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { NavBar } from '../NavBar';
+import { PageWrapper } from 'app/components/PageWrapper';
+import { translations } from 'locales/translations';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+export function ConfirmationPage() {
+  const { t } = useTranslation();
+
+  const  {state}  = useLocation();
+  // const { email, postalCode} = state;
+  // const [info, setInfo] = useState(state);
+  
+  useEffect(()=>{
+    console.log(state);
+  }, []);
+  return (
+    <>
+      <Helmet>
+        <title>{t(translations.homepage.title)}</title>
+        <meta
+          name="description"
+          content="confirmation page as asked"
+        />
+      </Helmet>
+      <NavBar />
+      <PageWrapper>
+      <p>{JSON.stringify(state)}</p>
+      {/* <p>{state.postalCode}</p> */}
+      </PageWrapper>
+    </>
+  );
+}

--- a/src/app/containers/Subscribe/TextError.ts
+++ b/src/app/containers/Subscribe/TextError.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components/macro';
+
+export const TextError = styled.p`
+  font-size: 1rem;
+  line-height: 1.5;
+  color: red;
+  margin: 0.625rem 0 1.5rem 0;
+  font-size: small;
+`;

--- a/src/app/containers/Subscribe/index.tsx
+++ b/src/app/containers/Subscribe/index.tsx
@@ -10,8 +10,62 @@ import { FormLabel } from 'app/components/FormLabel';
 import { Input } from 'app/components/Input';
 import { Button } from 'app/components/Button';
 
+import { useState } from 'react';
+import { isValidEmail, isValidPostalCode} from '../../../utils/validation';
+import axios from 'axios';
+import { Redirect } from 'react-router-dom';
+import { TextError } from './TextError';
+
 export function Subscribe() {
   const { t } = useTranslation();
+
+  const [info, setInfo] = useState({
+    email: '',
+    postalCode: ''
+  });
+  const [validEmail, setValidEmail] = useState(false);
+  const [validPostalCode, setValidPostalCode] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [errorMsgEmail, setErrorMsgEmail] = useState('');
+  const [errorMsgPostalCode, setErrorMsgPostalCode] = useState('');
+
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value as string;
+    setValidEmail(isValidEmail(value));
+    if(validPostalCode === false){
+      setErrorMsgEmail("Invalid Email format");
+    }
+    setInfo({...info, email:value});
+  };
+
+  const handlePostalCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = (event.target.value).toUpperCase() as string;
+    setValidPostalCode(isValidPostalCode(value));
+    if(validPostalCode === false){
+      setErrorMsgPostalCode("Invalid Postal Code format");
+    }
+    setInfo({...info, postalCode:value});
+  };
+
+  const handleSubmit = () => {
+    axios.post(`https://cors-anywhere.herokuapp.com/https://s9g64p6vzb.execute-api.us-east-1.amazonaws.com/default/interview-is-zip-valid`,{
+      zip: info.postalCode
+    }).then( res =>{
+      if(res.status === 200){
+        const data = res.data;
+        
+        if(data.has_error){
+          console.log(data.error_message);
+        } else{
+          setIsSuccess(true); 
+        }
+      }
+    })
+  }
+
+  if(isSuccess){
+    return <Redirect to={{pathname: '/confirmation', state: info}} />;
+  }
 
   return (
     <>
@@ -24,10 +78,26 @@ export function Subscribe() {
         <h1>{t(translations.subscribe.title)}</h1>
         <Form>
           <FormLabel htmlFor="email">{t(translations.subscribe.form.email)}</FormLabel>
-          <Input type="text" name="email" />
+          <Input 
+            type="text" 
+            name="email" 
+            value={info.email}
+            placeholder="example@example.com"
+            onChange={handleEmailChange}
+          /> 
+          <TextError>{!validEmail ? errorMsgEmail : null}</TextError>
+          
           <FormLabel htmlFor="postalCode">{t(translations.subscribe.form.postalCode)}</FormLabel>
-          <Input type="text" name="postalCode" />
-          <Button>{t(translations.subscribe.form.submit)}</Button>
+          <Input
+            type="text"
+            name="postalCode" 
+            value={info.postalCode}
+            placeholder="A1A 2B2"
+            onChange={handlePostalCodeChange}  
+          />
+          <TextError>{!validPostalCode ? errorMsgPostalCode : null}</TextError>
+          
+          <Button type="submit" value="Submit" disabled= {!(validEmail && validPostalCode)} onClick={handleSubmit}>{t(translations.subscribe.form.submit)}</Button>
         </Form>
       </Wrapper>
     </>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -17,6 +17,7 @@ import { GlobalStyle } from '../styles/global-styles';
 import { HomePage } from './containers/HomePage/Loadable';
 import { NotFoundPage } from './containers/NotFoundPage/Loadable';
 import { Subscribe } from './containers/Subscribe/Loadable';
+import { ConfirmationPage } from './containers/ConfirmationPage/Loadable';
 
 export function App() {
   const { t, i18n } = useTranslation();
@@ -32,6 +33,7 @@ export function App() {
       <Switch>
         <Route exact path={process.env.PUBLIC_URL + '/'} component={HomePage} />
         <Route exact path={process.env.PUBLIC_URL + '/subscribe'} component={Subscribe} />
+        <Route exact path={process.env.PUBLIC_URL + '/confirmation'} component={ConfirmationPage} />
         <Route component={NotFoundPage} />
       </Switch>
       <GlobalStyle />


### PR DESCRIPTION

- Added validation methods for subscription page using regex found in src/utils/validation.ts, validates onChange

- temporarily appended "https://cors-anywhere.herokuapp.com/" in front of api call to bypass cors issue (localhost request to https)

- used conditional rendering for invalid user input

- disabled submit button by default, enabling only when BOTH the email and postal code is in correct format

- Created new confirmation page that users will be redirected to if postal code is found in api (https://s9g64p6vzb.execute-api.us-east-1.amazonaws.com/default/interview-is-zip-valid)

- after adding new Route, fixed test case by updating snapshot

**Missing test cases**